### PR TITLE
disasm: fix pltgottargets handling when no matches are found

### DIFF
--- a/disasm/extern_symbol_process.py
+++ b/disasm/extern_symbol_process.py
@@ -62,7 +62,7 @@ def pltgot(filepath):
         items = l.strip().split()
         dest = int(items[4] if '#' in items else items[2].lstrip('*'), 16)
         return (int(items[0].rstrip(':'), 16), dest)
-    pltgottargets = dict(map(pltgotmapper, pltgottargets.strip().split('\n')))
+    pltgottargets = dict(map(pltgotmapper, filter(lambda x: len(x) > 0, pltgottargets.strip().split('\n'))))
     pltgottargets = {e[0]: '<' + pltgotsym[e[1]] + '@plt>' for e in pltgottargets.iteritems() if e[1] in pltgotsym}
     if len(pltgottargets) == 0: return
 


### PR DESCRIPTION
I ran into this problem on a Debian 10 (buster) system -- because of how Python's string `split` method works, an empty string was being passed to `pltgotmapper` when no matches were actually found.  Obviously this caused problems when trying to split the line and index inside the function.

It's possible the same problem may exist elsewhere, e.g., right above when mapping into the `pltsymmapper` function.  You might consider also fixing these potential problems.

Thanks.